### PR TITLE
Potential fix for code scanning alert no. 3: Incomplete multi-character sanitization

### DIFF
--- a/lib/security/validation.ts
+++ b/lib/security/validation.ts
@@ -247,12 +247,17 @@ export class XSSPrevention {
       .replace(/\//g, '&#x2F;')
     
     // Remove any remaining dangerous patterns
-    sanitized = sanitized
-      .replace(/javascript:/gi, '')
-      .replace(/vbscript:/gi, '')
-      .replace(/data:/gi, '')
-      .replace(/on\w+\s*=/gi, '')
-    
+    // Remove dangerous protocol and attribute patterns until stable
+    let previous;
+    do {
+      previous = sanitized;
+      sanitized = sanitized
+        .replace(/javascript:/gi, '')
+        .replace(/vbscript:/gi, '')
+        .replace(/data:/gi, '')
+        .replace(/on\w+\s*=/gi, '');
+    } while (sanitized !== previous);
+
     return sanitized
   }
 }


### PR DESCRIPTION
Potential fix for [https://github.com/TaskWork-io/TaskWork/security/code-scanning/3](https://github.com/TaskWork-io/TaskWork/security/code-scanning/3)

To fix the issue, the potentially dangerous pattern (`/on\w+\s*=/gi`) must be removed repeatedly from the string until no further matches are found. This prevents attack strings that re-form after the first replacement due to overlapping or nested input. The best approach is to wrap the replacements of dangerous patterns (including `javascript:`, `vbscript:`, `data:`, and `on\w+\s*=`) in a loop that continues until no replacements occur.

Moreover, since similar multi-character dangerous patterns are present (lines 251-254), all should be sanitized in this way. The best approach is to perform all these replacements (251-254) in a loop, or, since they're independent, iterate each pattern in a loop till stable.

The required edit is to refactor lines 250-255 of `performDeepSanitization` to loop through the dangerous patterns and keep applying replacements until the sanitized string stops changing.

No new dependencies are required, and this change only affects the `performDeepSanitization` method in `lib/security/validation.ts`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
